### PR TITLE
V2 load external handlebars helpers

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,6 +159,26 @@ const Yapl = {
      * Set up handlebars partials, register helpers, etc.
      */
     setupHandlebarsConfig() {
+        // register custom helpers
+        const helpers = utils.loadFiles(this.config.settings.helpers, '**/*.js');
+        helpers.forEach(helperPath => {
+            let helper;
+            const name = path.basename(helperPath, '.js');
+
+            try {
+                if (handlebars.helpers[name]){
+                    delete require.cache[require.resolve(path.join(helperPath))];
+                    handlebars.unregisterHelper(name);
+                }
+
+                helper = require(path.join(helperPath));
+                handlebars.registerHelper(name, helper);
+                }
+            catch (e) {
+                console.warn('Error when loading ' + name + '.js as a Handlebars helper.');
+            }
+        })
+
         let partials = glob.sync(this.config.settings.partials);
         // register all partials
         partials.forEach(partialPath => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -330,6 +330,22 @@ const utils = module.exports = {
         let relativePath = path.relative(root, link).replace(/\\/g, '/');
 
         return '/' + relativePath;
-    }
+    },
+
+
+    /**
+     * Load a set of files
+     * @param  {string|array} dir
+     * @param  {string}       pattern
+     * @return {array}
+     */
+    loadFiles(dir, pattern) {
+        let files = [];
+        dir = !Array.isArray(dir) ? [dir] : dir;
+        dir.forEach(file => {
+            file && (files = files.concat(glob.sync(path.join(process.cwd(), file, pattern))));
+        })
+        return files;
+      }
 
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,7 @@ const fs = require('fs'),
     path = require('path'),
     _ = require('lodash'),
     cheerio = require('cheerio'),
+    glob = require('glob'),
     parseScss = require('postcss-scss/lib/scss-parse');
 
 


### PR DESCRIPTION
Add ability to load custom handlebars helpers. Components using Foundation framework's built-in helpers were failing so I needed a way to add custom helpers to the yapl handlebars build.

The functionality itself (loadFiles and the handlebars helper registry code) comes directly from the Foundation framework implementation, with a couple of small edits.

@matt-diehl 