### PR TITLE
V2 override library assets by key

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,14 +112,16 @@ const Yapl = {
         });
 
         // Find any override asset paths
-        if (s.libraryAssetOverrideDir) {
+        if (s.libraryAssetOverrideDir && s.libraryAssetOverrides) {
             Object.keys(s.libraryAssets).forEach(assetKey => {
-                overrideAssets[assetKey] = path.join(
-                    s.libraryAssetOverrideDir,
-                    s.libraryAssets[assetKey]
-                );
+                if (s.libraryAssetOverrides[assetKey]) {
+                    overrideAssets[assetKey] = path.join(
+                        s.libraryAssetOverrideDir,
+                        s.libraryAssetOverrides[assetKey]
+                    );
 
-                overrideAssets[assetKey] = glob.sync(overrideAssets[assetKey]);
+                    overrideAssets[assetKey] = glob.sync(overrideAssets[assetKey]);
+                }
             });
         }
 


### PR DESCRIPTION
Allow overriding of individual library assets by key. Implemented this in order to override the pattern library logo like so:

```
yapl.init({
  settings: {
    libraryAssetOverrideDir: 'src/',
    libraryAssetOverrides: {
      logo: 'assets/img/pl-logo.png'
    }
    ...
  }
  ...
})
```
@matt-diehl 